### PR TITLE
Use default test fixtures in export command tests

### DIFF
--- a/pootle/apps/import_export/management/commands/export.py
+++ b/pootle/apps/import_export/management/commands/export.py
@@ -81,7 +81,7 @@ class Command(PootleCommand):
         stores = Store.objects.live().filter(
             translation_project__project=project)
         if not stores:
-            raise CommandError("No matches for project %r" % (project))
+            raise CommandError("No matches for project '%s'" % (project))
         self._create_zip(stores, prefix=project.code)
 
     def handle_language(self, language, **options):
@@ -92,14 +92,14 @@ class Command(PootleCommand):
     def handle_path(self, path, **options):
         stores = Store.objects.live().filter(pootle_path__startswith=path)
         if not stores:
-            raise CommandError("Could not find store matching %r" % (path))
+            raise CommandError("Could not find store matching '%s'" % (path))
 
         if stores.count() == 1:
             store = stores.get()
             with open(os.path.basename(store.pootle_path), "wb") as f:
                 f.write(store.serialize())
 
-            self.stdout.write("Created %r" % (f.name))
+            self.stdout.write("Created '%s'" % (f.name))
             return
 
         prefix = path.strip("/").replace("/", "-")

--- a/tests/commands/export.py
+++ b/tests/commands/export.py
@@ -9,6 +9,7 @@
 import pytest
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 
 @pytest.mark.cmd
@@ -31,9 +32,52 @@ def test_export_project(capfd, afrikaans_tutorial, french_tutorial):
 
 @pytest.mark.cmd
 @pytest.mark.django_db
+def test_export_project_and_lang(capfd, afrikaans_tutorial, french_tutorial):
+    """Export a project TP"""
+    call_command('export', '--project=tutorial', '--language=af')
+    out, err = capfd.readouterr()
+    assert 'tutorial-af.zip' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
 def test_export_language(capfd, afrikaans_tutorial, french_tutorial):
     """Export a language"""
     call_command('export', '--language=af')
     out, err = capfd.readouterr()
     assert 'af.zip' in out
     assert 'fr.zip' not in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_path(capfd, afrikaans_tutorial, french_tutorial):
+    """Export a path
+
+    Testing variants of lang, TP, single PO file and whole site.
+    """
+    call_command('export', '--path=/af')
+    out, err = capfd.readouterr()
+    assert 'af.zip' in out
+    assert 'fr.zip' not in out
+
+    call_command('export', '--path=/af/tutorial')
+    out, err = capfd.readouterr()
+    assert 'af-tutorial.zip' in out
+
+    call_command('export', '--path=/af/tutorial/tutorial.po')
+    out, err = capfd.readouterr()
+    assert 'tutorial.po' in out
+
+    call_command('export', '--path=/')
+    out, err = capfd.readouterr()
+    assert 'export.zip' in out
+
+
+@pytest.mark.cmd
+@pytest.mark.django_db
+def test_export_path_unknown():
+    """Export an unknown path"""
+    with pytest.raises(CommandError) as e:
+        call_command('export', '--path=/af/unknown')
+    assert "Could not find store matching '/af/unknown'" in str(e)

--- a/tests/commands/export.py
+++ b/tests/commands/export.py
@@ -14,60 +14,60 @@ from django.core.management.base import CommandError
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_noargs(capfd, en_tutorial_po_member_updated):
+def test_export_noargs(capfd):
     """Export whole site"""
     call_command('export')
     out, err = capfd.readouterr()
-    assert 'Created tutorial-en.zip' in out
+    assert 'Created project0-language0.zip' in out
 
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_project(capfd, afrikaans_tutorial, french_tutorial):
+def test_export_project(capfd):
     """Export a project"""
-    call_command('export', '--project=tutorial')
+    call_command('export', '--project=project0')
     out, err = capfd.readouterr()
-    assert 'tutorial.zip' in out
+    assert 'project0.zip' in out
 
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_project_and_lang(capfd, afrikaans_tutorial, french_tutorial):
+def test_export_project_and_lang(capfd):
     """Export a project TP"""
-    call_command('export', '--project=tutorial', '--language=af')
+    call_command('export', '--project=project0', '--language=language0')
     out, err = capfd.readouterr()
-    assert 'tutorial-af.zip' in out
+    assert 'project0-language0.zip' in out
 
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_language(capfd, afrikaans_tutorial, french_tutorial):
+def test_export_language(capfd):
     """Export a language"""
-    call_command('export', '--language=af')
+    call_command('export', '--language=language0')
     out, err = capfd.readouterr()
-    assert 'af.zip' in out
-    assert 'fr.zip' not in out
+    assert 'language0.zip' in out
+    assert 'language1.zip' not in out
 
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_export_path(capfd, afrikaans_tutorial, french_tutorial):
+def test_export_path(capfd):
     """Export a path
 
     Testing variants of lang, TP, single PO file and whole site.
     """
-    call_command('export', '--path=/af')
+    call_command('export', '--path=/language0')
     out, err = capfd.readouterr()
-    assert 'af.zip' in out
-    assert 'fr.zip' not in out
+    assert 'language0.zip' in out
+    assert 'language1.zip' not in out
 
-    call_command('export', '--path=/af/tutorial')
+    call_command('export', '--path=/language0/project0')
     out, err = capfd.readouterr()
-    assert 'af-tutorial.zip' in out
+    assert 'language0-project0.zip' in out
 
-    call_command('export', '--path=/af/tutorial/tutorial.po')
+    call_command('export', '--path=/language0/project0/store0.po')
     out, err = capfd.readouterr()
-    assert 'tutorial.po' in out
+    assert 'store0.po' in out
 
     call_command('export', '--path=/')
     out, err = capfd.readouterr()


### PR DESCRIPTION
updates command export tests to use default fixtures, considerably optimizing the tests
